### PR TITLE
Feature/gateway-specific-fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,12 @@ setup(
     packages=['spreedly_sdk'],
     scripts=[],
     test_suite='tests',
+    test_require=['mock'],
     zip_safe=False,
     url='https://github.com/calvinpy',
     license='Apache Software License',
     description='Python Interface to the Spreedly API',
-    install_requires=['requests>=1.1.0', 'lxml', 'xmltodict'],
+    install_requires=['requests>=1.1.0', 'lxml', 'xmltodict', 'python-dateutil'],
     dependency_links=[
         'https://github.com/kennethreitz/requests',
         'https://github.com/lxml/lxml/',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='spreedly-sdk',
-    version='0.1.0',
+    version='0.1.1',
     author='calvin',
     author_email='dani@aplaza.me',
     packages=['spreedly_sdk'],

--- a/spreedly_sdk/__init__.py
+++ b/spreedly_sdk/__init__.py
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 import requests
 import xmltodict


### PR DESCRIPTION
- Fixes tests in development
- Adds a way to provide extra parameters in **purchase** endpoint (it also works with **authorize** endpoint since it calls purchase inside its implementation):
  Using `gateway_specific_fields` parameter now you can provide a python dict representing the elements that will be added to the XML request (ie: `gateway_specific_fields={'openpay': {'device_session_id': '2121sf3433'}}`)
- Updates setup.py with new version and missing requirements